### PR TITLE
Adiciona campo para configuração da Temperatura ao corpo da request para a API

### DIFF
--- a/api/integrations/openAiIntegration.js
+++ b/api/integrations/openAiIntegration.js
@@ -34,6 +34,7 @@ const streamOpenAiText2Sql = async (prompt) => {
                     content: prompt 
                 },
             ],
+            temperature: 0,
             model: "gpt-4-turbo",
             response_format: { 
                 type: "json_object" 


### PR DESCRIPTION
Adiciona o campo de temperatura para deixar o retorno da API mais acurado e não mais puxado para o randomico como é feito com o valor padrão de **0.75**.